### PR TITLE
chore: centralize external links in shared config

### DIFF
--- a/apps/web/modules/ui/components/landing/cta-section.tsx
+++ b/apps/web/modules/ui/components/landing/cta-section.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { config } from "@onecontext/config";
 import { fadeUp, stagger } from "@ui/lib/animations";
 import { motion } from "framer-motion";
 import { ArrowRight, Github } from "lucide-react";
@@ -40,7 +41,7 @@ export function CTASection() {
 							Start Free
 						</Button>
 						<Button
-							href="https://github.com/onecontext"
+							href={config.links.github}
 							variant="secondary"
 							icon={<Github className="h-4 w-4" />}
 							iconPosition="left"

--- a/apps/web/modules/ui/components/landing/footer.tsx
+++ b/apps/web/modules/ui/components/landing/footer.tsx
@@ -1,17 +1,18 @@
 "use client";
 
+import { config } from "@onecontext/config";
 import { Github, Twitter } from "lucide-react";
 import { Logo } from "./logo";
 
 const footerLinks = [
 	{ href: "/docs", label: "Docs" },
 	{
-		href: "https://github.com/onecontext",
+		href: config.links.github,
 		label: "GitHub",
 		external: true,
 	},
 	{
-		href: "https://twitter.com/onecontext",
+		href: config.links.twitter,
 		label: "Twitter",
 		external: true,
 	},
@@ -20,12 +21,12 @@ const footerLinks = [
 
 const socialLinks = [
 	{
-		href: "https://github.com/onecontext",
+		href: config.links.github,
 		icon: Github,
 		label: "GitHub",
 	},
 	{
-		href: "https://twitter.com/onecontext",
+		href: config.links.twitter,
 		icon: Twitter,
 		label: "Twitter",
 	},

--- a/apps/web/modules/ui/components/landing/hero.tsx
+++ b/apps/web/modules/ui/components/landing/hero.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { config } from "@onecontext/config";
 import { fadeUp, stagger } from "@ui/lib/animations";
 import { motion } from "framer-motion";
 import { ArrowRight, Github } from "lucide-react";
@@ -76,7 +77,7 @@ export function Hero() {
 							Get Early Access
 						</Button>
 						<Button
-							href="https://github.com/onecontext"
+							href={config.links.github}
 							variant="secondary"
 							icon={<Github className="h-4 w-4" />}
 							iconPosition="left"

--- a/apps/web/modules/ui/components/landing/navbar.tsx
+++ b/apps/web/modules/ui/components/landing/navbar.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { config } from "@onecontext/config";
 import { Github } from "lucide-react";
 import { Logo } from "./logo";
 
 const navLinks = [
 	{ href: "#how-it-works", label: "How it works" },
 	{ href: "#features", label: "Features" },
-	{ href: "https://github.com/onecontext", label: "GitHub", external: true },
+	{ href: config.links.github, label: "GitHub", external: true },
 	{ href: "/docs", label: "Docs" },
 ];
 
@@ -32,7 +33,7 @@ export function Navbar() {
 				</div>
 				<div className="flex items-center gap-3">
 					<a
-						href="https://github.com/onecontext"
+						href={config.links.github}
 						target="_blank"
 						rel="noopener noreferrer"
 						className="hidden rounded-md p-2 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground sm:inline-flex"

--- a/config/index.ts
+++ b/config/index.ts
@@ -3,6 +3,10 @@ import type { Config } from "./types";
 export type { Config } from "./types";
 
 export const config: Config = {
+	links: {
+		github: "https://github.com/robinfaraj/one-context",
+		twitter: "https://twitter.com/onecontext",
+	},
 	auth: {
 		enableSignup: true,
 		enableSocialLogin: true,

--- a/config/types.ts
+++ b/config/types.ts
@@ -1,4 +1,8 @@
 export type Config = {
+	links: {
+		github: string;
+		twitter: string;
+	};
 	auth: {
 		enableSignup: boolean;
 		enableSocialLogin: boolean;


### PR DESCRIPTION
## Summary
- Add `links.github` and `links.twitter` to `@onecontext/config`
- Replace all hardcoded GitHub/Twitter URLs in landing page components (navbar, hero, footer, CTA) with `config.links.*`
- Fix GitHub URL to point to correct repo (`robinfaraj/one-context`)

## Test plan
- [ ] Verify all landing page GitHub links open `https://github.com/robinfaraj/one-context`
- [ ] Verify footer Twitter link still works
- [ ] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)