### PR TITLE
chore: exclude apps/video from biome linting

### DIFF
--- a/apps/web/modules/(marketing)/components/hero.tsx
+++ b/apps/web/modules/(marketing)/components/hero.tsx
@@ -104,8 +104,8 @@ export function Hero() {
 								octx login
 							</p>
 							<p className="text-[var(--terminal-text)]">
-								<span className="text-[var(--terminal-success)]">✓</span>{" "}
-								Logged in as Robin Faraj (robin@onecontext.dev)
+								<span className="text-[var(--terminal-success)]">✓</span> Logged
+								in as Robin Faraj (robin@onecontext.dev)
 							</p>
 							<p className="mt-2 text-[var(--terminal-text-dim)]">
 								<span className="text-[var(--terminal-success)]">$</span> npx

--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,7 @@
 	},
 	"files": {
 		"ignore": [
+			"apps/video",
 			".next",
 			".turbo",
 			"node_modules/*",


### PR DESCRIPTION
## Summary
- Adds `apps/video` to the Biome `files.ignore` list, removing 51 lint errors from the internal-only video project
- Fixes a pre-existing formatting issue in `hero.tsx`

## Test plan
- [x] Verified `biome check apps/video/` no longer reports any files
- [x] No impact on linting for other apps/packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)